### PR TITLE
Add 'type' parameter to XML upload endpoint

### DIFF
--- a/src/main/java/com/project/demo/logic/entity/xml/XmlService.java
+++ b/src/main/java/com/project/demo/logic/entity/xml/XmlService.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Service
 public class XmlService {
 
-    public Invoice formatAndSave(InputStream inputStream) throws Exception {
+    public Invoice formatAndSave(InputStream inputStream, String type) throws Exception {
         try {
             Document document = DocumentBuilderFactory.newInstance()
                     .newDocumentBuilder()
@@ -26,6 +26,7 @@ public class XmlService {
 
             Invoice invoice = new Invoice();
 
+            invoice.setType(type);
             invoice.setConsecutive(getText(document, "NumeroConsecutivo"));
 
             invoice.setInvoiceKey(getText(document, "Clave"));

--- a/src/main/java/com/project/demo/rest/xml/XmlRestController.java
+++ b/src/main/java/com/project/demo/rest/xml/XmlRestController.java
@@ -22,14 +22,12 @@ public class XmlRestController {
 
     @PostMapping
     @PreAuthorize("hasAnyRole('SUPER_ADMIN','USER')")
-    public ResponseEntity<?> upload(@RequestParam("file") MultipartFile file, HttpServletRequest request) {
+    public ResponseEntity<?> upload(@RequestParam("file") MultipartFile file, @RequestParam("type") String type, HttpServletRequest request) {
         try (InputStream inputStream = file.getInputStream()) {
-            Invoice saved = xmlService.formatAndSave(inputStream);
-            System.out.println("Escaneco de ml realizado con exito"+saved.toString());
+            Invoice saved = xmlService.formatAndSave(inputStream, type);
             return new GlobalResponseHandler().handleResponse("Procesamiento exitoso", saved, HttpStatus.OK,request);
         } catch (Exception e) {
             return ResponseEntity.internalServerError().build();
         }
     }
-    
 }


### PR DESCRIPTION
This pull request introduces changes to support the inclusion of an invoice type in the XML processing workflow. The modifications affect both the service layer and the controller layer, ensuring that the invoice type can be passed, processed, and saved correctly.

### Service Layer Enhancements:
* [`src/main/java/com/project/demo/logic/entity/xml/XmlService.java`](diffhunk://#diff-51c8161e7573ec2c91ff8a2ac8789f2981488ce84a602475a74efe89c8894080L20-R20): Updated the `formatAndSave` method to accept an additional `type` parameter and set the invoice type during processing. [[1]](diffhunk://#diff-51c8161e7573ec2c91ff8a2ac8789f2981488ce84a602475a74efe89c8894080L20-R20) [[2]](diffhunk://#diff-51c8161e7573ec2c91ff8a2ac8789f2981488ce84a602475a74efe89c8894080R29)

### Controller Layer Enhancements:
* [`src/main/java/com/project/demo/rest/xml/XmlRestController.java`](diffhunk://#diff-0b386ab6bc61235864037c1bf8b103c4add8ad1dc981a7303dbd65b1b6c095c7L25-L34): Modified the `upload` method to include a new `type` parameter in the request, which is passed to the service layer for processing.