### PR TITLE
Add chatbot module for tax-related Q&A in Costa Rica

### DIFF
--- a/src/main/java/com/project/demo/logic/entity/chatbot/ChatbotConfiguration.java
+++ b/src/main/java/com/project/demo/logic/entity/chatbot/ChatbotConfiguration.java
@@ -1,0 +1,33 @@
+package com.project.demo.logic.entity.chatbot;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ChatbotConfiguration {
+
+    @Bean
+    ChatClient chatClient(ChatModel chatModel) {
+        String defaultSystemPrompt = """
+        You are a chatbot named 'Tributario'. Your role is to assist users with tax-related questions specific to Costa Rica.
+        You specialize in helping **freelancers and independent professionals** who manage all their tax-related obligations exclusively through the **ATV (Administración Tributaria Virtual) system of Hacienda**.
+    
+        All forms, declarations, payments, and updates must be assumed to occur **only within the ATV system**. 
+        Do not reference or suggest any external platforms, government institutions, or third-party services.
+        
+        Users will ask questions in English. You may internally translate their input to better understand the question, but you must always reply in Spanish.
+    
+        Only respond to questions related to **personal tax matters** in Costa Rica for **independent professionals**, and strictly within the context of the **ATV system**.
+        
+        If the user asks about anything outside this scope (e.g., corporate taxes, payroll, legal entities, immigration, other government systems), reply with:
+        "Lo siento, estoy aquí para ayudarte con temas de tributación como profesional independiente en el sistema ATV de Hacienda. No puedo responder otras preguntas."
+        """;
+
+        return ChatClient
+                .builder(chatModel)
+                .defaultSystem(defaultSystemPrompt)
+                .build();
+    }
+}

--- a/src/main/java/com/project/demo/logic/entity/chatbot/ChatbotReponse.java
+++ b/src/main/java/com/project/demo/logic/entity/chatbot/ChatbotReponse.java
@@ -1,0 +1,29 @@
+package com.project.demo.logic.entity.chatbot;
+
+import java.util.UUID;
+
+public class ChatbotReponse {
+    private UUID chatId;
+    private String answer;
+
+    public ChatbotReponse(UUID chatId, String answer) {
+        this.chatId = chatId;
+        this.answer = answer;
+    }
+
+    public UUID getChatId() {
+        return chatId;
+    }
+
+    public void setChatId(UUID chatId) {
+        this.chatId = chatId;
+    }
+
+    public String getAnswer() {
+        return answer;
+    }
+
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+}

--- a/src/main/java/com/project/demo/logic/entity/chatbot/ChatbotRequest.java
+++ b/src/main/java/com/project/demo/logic/entity/chatbot/ChatbotRequest.java
@@ -1,0 +1,33 @@
+package com.project.demo.logic.entity.chatbot;
+
+import org.springframework.lang.Nullable;
+
+import java.util.UUID;
+
+public class ChatbotRequest {
+    @Nullable
+    private UUID chatId;
+    private String question;
+
+    @Nullable
+    public UUID getChatId() {
+        return chatId;
+    }
+
+    public ChatbotRequest(@Nullable UUID chatId, String question) {
+        this.chatId = chatId;
+        this.question = question;
+    }
+
+    public void setChatId(@Nullable UUID chatId) {
+        this.chatId = chatId;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+
+    public void setQuestion(String question) {
+        this.question = question;
+    }
+}

--- a/src/main/java/com/project/demo/logic/entity/chatbot/ChatbotService.java
+++ b/src/main/java/com/project/demo/logic/entity/chatbot/ChatbotService.java
@@ -1,0 +1,28 @@
+package com.project.demo.logic.entity.chatbot;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.ollama.api.OllamaApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class ChatbotService {
+
+    @Autowired
+    private ChatClient chatClient;
+
+    public ChatbotReponse chat(ChatbotRequest chatbotRequest) {
+        UUID chatId = Optional.ofNullable(chatbotRequest.getChatId()).orElse(UUID.randomUUID());
+        String answer = chatClient
+                .prompt()
+                .user(chatbotRequest.getQuestion())
+                .advisors(advisorSpec -> advisorSpec.param("chat_memory_conversation_id", chatId))
+                .call()
+                .content();
+        return new ChatbotReponse(chatId, answer);
+    }
+}

--- a/src/main/java/com/project/demo/rest/chatbot/ChatbotRestController.java
+++ b/src/main/java/com/project/demo/rest/chatbot/ChatbotRestController.java
@@ -1,0 +1,28 @@
+package com.project.demo.rest.chatbot;
+
+import com.project.demo.logic.entity.chatbot.ChatbotReponse;
+import com.project.demo.logic.entity.chatbot.ChatbotRequest;
+import com.project.demo.logic.entity.chatbot.ChatbotService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/chatbot")
+public class ChatbotRestController {
+
+    @Autowired
+    private ChatbotService chatbotService;
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('SUPER_ADMIN', 'USER')")
+    public ResponseEntity<ChatbotReponse> askChatbot(@RequestBody ChatbotRequest chatbotRequest) {
+        ChatbotReponse answer = chatbotService.chat(chatbotRequest);
+        return ResponseEntity.ok(answer);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new chatbot feature focused on assisting independent professionals in Costa Rica with tax-related questions through the ATV system. The implementation includes a REST API endpoint, service logic, configuration, and request/response models. The main changes are grouped below:

**Chatbot Feature Implementation**

* Added `ChatbotRestController` to expose a secured POST endpoint `/chatbot` for handling chatbot queries, restricted to users with `SUPER_ADMIN` or `USER` roles.
* Implemented `ChatbotService` to process incoming requests, manage chat sessions using UUIDs, and interact with the AI chat client to generate responses.

**Chatbot Configuration and Domain Models**

* Created `ChatbotConfiguration` to define a Spring bean for `ChatClient` with a detailed system prompt tailored for Costa Rican freelance tax queries, ensuring scope and language constraints.
* Introduced `ChatbotRequest` and `ChatbotReponse` classes to model the request and response payloads for chatbot interactions, including support for session-based conversation via `chatId`. [[1]](diffhunk://#diff-b75132900e20e351f26b188fb5dd9cf8c58f890581756e8e1616291d9e46c4bcR1-R33) [[2]](diffhunk://#diff-9a41e0d6b1efcb7212446db5422fe1e93e7a8f811a18dc209077b9c1902c6f35R1-R29)Introduces a chatbot feature focused on assisting freelancers and independent professionals with tax questions specific to Costa Rica's ATV system. Adds configuration, request/response models, service logic, and a secured REST controller endpoint for chatbot interactions.